### PR TITLE
bump(jdtls): Update to v.1.54.0

### DIFF
--- a/packages/jdtls/package.yaml
+++ b/packages/jdtls/package.yaml
@@ -10,26 +10,26 @@ categories:
   - LSP
 
 source:
-  id: pkg:generic/eclipse/eclipse.jdt.ls@v1.51.0
+  id: pkg:generic/eclipse/eclipse.jdt.ls@v1.54.0
   download:
     - target: darwin_x64
       files:
-        jdtls.tar.gz: https://download.eclipse.org/jdtls/milestones/{{ version | strip_prefix "v" }}/jdt-language-server-{{ version | strip_prefix "v" }}-202510022025.tar.gz
+        jdtls.tar.gz: https://download.eclipse.org/jdtls/milestones/{{ version | strip_prefix "v }}/jdt-language-server-{{ version | strip_prefix "v" }}-202511261751.tar.gz
         lombok.jar: https://projectlombok.org/downloads/lombok.jar
       config: config_mac/
     - target: darwin_arm64
       files:
-        jdtls.tar.gz: https://download.eclipse.org/jdtls/milestones/{{ version | strip_prefix "v" }}/jdt-language-server-{{ version | strip_prefix "v" }}-202510022025.tar.gz
+        jdtls.tar.gz: https://download.eclipse.org/jdtls/milestones/{{ version | strip_prefix "v" }}/jdt-language-server-{{ version | strip_prefix "v" }}-202511261751.tar.gz
         lombok.jar: https://projectlombok.org/downloads/lombok.jar
       config: config_mac_arm/
     - target: linux
       files:
-        jdtls.tar.gz: https://download.eclipse.org/jdtls/milestones/{{ version | strip_prefix "v" }}/jdt-language-server-{{ version | strip_prefix "v" }}-202510022025.tar.gz
+        jdtls.tar.gz: https://download.eclipse.org/jdtls/milestones/{{ version | strip_prefix "v" }}/jdt-language-server-{{ version | strip_prefix "v" }}-202511261751.tar.gz
         lombok.jar: https://projectlombok.org/downloads/lombok.jar
       config: config_linux/
     - target: win
       files:
-        jdtls.tar.gz: https://download.eclipse.org/jdtls/milestones/{{ version | strip_prefix "v" }}/jdt-language-server-{{ version | strip_prefix "v" }}-202510022025.tar.gz
+        jdtls.tar.gz: https://download.eclipse.org/jdtls/milestones/{{ version | strip_prefix "v" }}/jdt-language-server-{{ version | strip_prefix "v" }}-202511261751.tar.gz
         lombok.jar: https://projectlombok.org/downloads/lombok.jar
       config: config_win/
 
@@ -42,7 +42,7 @@ bin:
 share:
   jdtls/lombok.jar: lombok.jar
   jdtls/plugins/: plugins/
-  jdtls/plugins/org.eclipse.equinox.launcher.jar: plugins/org.eclipse.equinox.launcher_1.7.0.v20250519-0528.jar
+  jdtls/plugins/org.eclipse.equinox.launcher.jar: plugins/org.eclipse.equinox.launcher_1.7.100.v20251111-0406.jar
   jdtls/config/: "{{source.download.config}}"
 
 neovim:


### PR DESCRIPTION
This pull request updates the Eclipse JDT Language Server (`jdtls`) package to a newer version and updates related resource references. The main focus is on keeping the language server and its dependencies up to date for all supported platforms.

Dependency and resource updates:

* Upgraded the `eclipse.jdt.ls` package version from `v1.51.0` to `v1.54.0` in `package.yaml`, ensuring the latest features and fixes are available.
* Updated the download URLs for the `jdt-language-server` tarballs across all platforms to point to the new `202511261751` milestone build, matching the upgraded version.
* Updated the `org.eclipse.equinox.launcher.jar` reference to version `1.7.100.v20251111-0406` (from `1.7.0.v20250519-0528`) in the shared resources, aligning with the new JDT LS version.