### PR TITLE
bump(java-debug-adapter): Update to v0.58.3

### DIFF
--- a/packages/java-debug-adapter/package.yaml
+++ b/packages/java-debug-adapter/package.yaml
@@ -10,10 +10,10 @@ categories:
   - DAP
 
 source:
-  id: pkg:openvsx/vscjava/vscode-java-debug@0.58.1
+  id: pkg:openvsx/vscjava/vscode-java-debug@0.58.3
   download:
     file: vscjava.vscode-java-debug-{{version}}.vsix
 
 share:
   java-debug-adapter/: extension/server/
-  java-debug-adapter/com.microsoft.java.debug.plugin.jar: extension/server/com.microsoft.java.debug.plugin-0.53.1.jar
+  java-debug-adapter/com.microsoft.java.debug.plugin.jar: extension/server/com.microsoft.java.debug.plugin-0.53.2.jar


### PR DESCRIPTION
This pull request updates the `packages/java-debug-adapter` package to use newer versions of its dependencies.

Dependency version updates:

* Updated the `vscode-java-debug` extension source from version `0.58.1` to `0.58.3` in `package.yaml`.
* Updated the `com.microsoft.java.debug.plugin.jar` from version `0.53.1` to `0.53.2` in `package.yaml`.