### PR TITLE
bump(jdtls): Update to v.1.56.0

### DIFF
--- a/packages/jdtls/package.yaml
+++ b/packages/jdtls/package.yaml
@@ -10,26 +10,26 @@ categories:
   - LSP
 
 source:
-  id: pkg:generic/eclipse/eclipse.jdt.ls@v1.54.0
+  id: pkg:generic/eclipse/eclipse.jdt.ls@v1.56.0
   download:
     - target: darwin_x64
       files:
-        jdtls.tar.gz: https://download.eclipse.org/jdtls/milestones/{{ version | strip_prefix "v }}/jdt-language-server-{{ version | strip_prefix "v" }}-202511261751.tar.gz
+        jdtls.tar.gz: https://download.eclipse.org/jdtls/milestones/{{ version | strip_prefix "v" }}/jdt-language-server-{{ version | strip_prefix "v" }}-202601291528.tar.gz
         lombok.jar: https://projectlombok.org/downloads/lombok.jar
       config: config_mac/
     - target: darwin_arm64
       files:
-        jdtls.tar.gz: https://download.eclipse.org/jdtls/milestones/{{ version | strip_prefix "v" }}/jdt-language-server-{{ version | strip_prefix "v" }}-202511261751.tar.gz
+        jdtls.tar.gz: https://download.eclipse.org/jdtls/milestones/{{ version | strip_prefix "v" }}/jdt-language-server-{{ version | strip_prefix "v" }}-202601291528.tar.gz
         lombok.jar: https://projectlombok.org/downloads/lombok.jar
       config: config_mac_arm/
     - target: linux
       files:
-        jdtls.tar.gz: https://download.eclipse.org/jdtls/milestones/{{ version | strip_prefix "v" }}/jdt-language-server-{{ version | strip_prefix "v" }}-202511261751.tar.gz
+        jdtls.tar.gz: https://download.eclipse.org/jdtls/milestones/{{ version | strip_prefix "v" }}/jdt-language-server-{{ version | strip_prefix "v" }}-202601291528.tar.gz
         lombok.jar: https://projectlombok.org/downloads/lombok.jar
       config: config_linux/
     - target: win
       files:
-        jdtls.tar.gz: https://download.eclipse.org/jdtls/milestones/{{ version | strip_prefix "v" }}/jdt-language-server-{{ version | strip_prefix "v" }}-202511261751.tar.gz
+        jdtls.tar.gz: https://download.eclipse.org/jdtls/milestones/{{ version | strip_prefix "v" }}/jdt-language-server-{{ version | strip_prefix "v" }}-202601291528.tar.gz
         lombok.jar: https://projectlombok.org/downloads/lombok.jar
       config: config_win/
 


### PR DESCRIPTION
This pull request updates the Eclipse JDT Language Server version used in the `jdtls` package. The main change is upgrading from version 1.54.0 to 1.56.0, along with updating the corresponding download URLs for all supported platforms.

Dependency update:

* Upgraded the Eclipse JDT Language Server from version 1.54.0 to 1.56.0 in `package.yaml`, and updated all related download URLs for macOS (x64 and arm64), Linux, and Windows targets to point to the new release.